### PR TITLE
Fixed types for ARM aarch64

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -36,13 +36,13 @@ pub fn parse_bytes(file_string_as_bytes: Vec<u8>, url: &str) -> Result<Styleshee
 
         let bytes = xsl_file_c_str.as_bytes_with_nul();
         let ptr = bytes.as_ptr();
-        let file = ptr as *const i8;
+        let file = ptr as *const libc::c_char;
 
         let bytes = url_c_str.as_bytes_with_nul();
         let ptr = bytes.as_ptr();
-        let url = ptr as *const i8;
+        let url = ptr as *const libc::c_char;
 
-        let xml = xmlReadMemory(file, xsl_file_string_len, url, std::ptr::null::<i8>(), 0);
+        let xml = xmlReadMemory(file, xsl_file_string_len, url, std::ptr::null::<libc::c_char>(), 0);
 
         let ptr = xsltParseStylesheetDoc(xml);
 

--- a/src/stylesheet.rs
+++ b/src/stylesheet.rs
@@ -47,7 +47,7 @@ impl Stylesheet {
 
     let params_cstrings = params_cstrings_result?;
 
-    let mut params_cstrings_pointers: Vec<*const i8> =  params_cstrings.iter()
+    let mut params_cstrings_pointers: Vec<*const libc::c_char> =  params_cstrings.iter()
         .map(|cstr| cstr.as_ptr())
         .collect();
 


### PR DESCRIPTION
Hi,

similarly to [this](https://github.com/remacs/remacs/issues/1393), char is unsigned on my target platform (Docker on an ARM Macbook), so with existing types I can't compile the project

```
 error[E0308]: mismatched types
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/libxslt-0.1.2/src/parser.rs:45:33
    |
 45 |         let xml = xmlReadMemory(file, xsl_file_string_len, url, std::ptr::null::<i8>(), 0);
    |                                 ^^^^ expected `u8`, found `i8`
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`

 error[E0308]: mismatched types
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/libxslt-0.1.2/src/parser.rs:45:60
    |
 45 |         let xml = xmlReadMemory(file, xsl_file_string_len, url, std::ptr::null::<i8>(), 0);
    |                                                            ^^^ expected `u8`, found `i8`
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`

 error[E0308]: mismatched types
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/libxslt-0.1.2/src/parser.rs:45:65
    |
 45 |         let xml = xmlReadMemory(file, xsl_file_string_len, url, std::ptr::null::<i8>(), 0);
    |                                                                 ^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`

 error[E0277]: a value of type `Vec<*const i8>` cannot be built from an iterator over elements of type `*const u8`
     --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/libxslt-0.1.2/src/stylesheet.rs:52:10
      |
 52   |         .collect();
      |          ^^^^^^^ value of type `Vec<*const i8>` cannot be built from `std::iter::Iterator<Item=*const u8>`
      |
      = help: the trait `FromIterator<*const u8>` is not implemented for `Vec<*const i8>`
 note: required by a bound in `collect`

 error[E0308]: mismatched types
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/libxslt-0.1.2/src/stylesheet.rs:63:9
    |
 63 |         params_ptr,
    |         ^^^^^^^^^^ expected `u8`, found `i8`
    |
    = note: expected raw pointer `*mut *const u8`
               found raw pointer `*mut *const i8`
```